### PR TITLE
Return Philosophers Stone from conversion recipe instead of Discharged Stone

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Use these Java versions
         java: [
-          16    # Minimum supported by Minecraft
+          17    # Minimum supported by Minecraft
         ]
         # and run on both Linux and Windows
         os: [ubuntu-20.04, windows-latest]
@@ -32,7 +32,7 @@ jobs:
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        if: ${{ runner.os == 'Linux' && matrix.java == '16' }} # Only upload artifacts built from latest java on one OS
+        if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
         uses: actions/upload-artifact@v2
         with:
           name: Artifacts

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.8-SNAPSHOT'
+	id 'fabric-loom' version '0.10-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -20,12 +20,12 @@ repositories {
 
 dependencies {
 	// To change the versions see the gradle.properties file
-	minecraft "com.mojang:minecraft:1.17"
-	mappings "net.fabricmc:yarn:1.17+build.13:v2"
-	modImplementation "net.fabricmc:fabric-loader:0.11.6"
+	minecraft "com.mojang:minecraft:${project.minecraft_version}"
+	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
+	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:0.35.2+1.17"
+	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ plugins {
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -46,8 +46,8 @@ tasks.withType(JavaCompile).configureEach {
 	// If Javadoc is generated, this must be specified in that task too.
 	it.options.encoding = "UTF-8"
 
-	// Minecraft 1.17 (21w19a) upwards uses Java 16.
-	it.options.release = 16
+	// Minecraft 1.18 upwards uses Java 17.
+	it.options.release = 17
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx4G
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
 	minecraft_version=1.18.1
-	yarn_mappings=1.18+build.2
+	yarn_mappings=1.18.1+build.2
 	loader_version=0.12.11
 
 # Mod Properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,15 @@ org.gradle.jvmargs=-Xmx4G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/versions.html
-	minecraft_version=1.17
-	yarn_mappings=1.17+build.13
-	loader_version=0.11.6
+	minecraft_version=1.18.1
+	yarn_mappings=1.18+build.2
+	loader_version=0.12.11
 
 # Mod Properties
-	mod_version = 1.2.1
+	mod_version = 1.2.3
 	maven_group = com.lemon.equivalence
 	archives_base_name = equivalence
 
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api (or https://fabricmc.net/versions.html)
-	fabric_version=0.36.0+1.17
+	fabric_version=0.44.0+1.18

--- a/src/main/java/com/lemon/equivalence/Equivalence.java
+++ b/src/main/java/com/lemon/equivalence/Equivalence.java
@@ -3,6 +3,7 @@ package com.lemon.equivalence;
 import com.lemon.equivalence.loot_tables.LootTableAdditions;
 import com.lemon.equivalence.registry.ModBlocks;
 import com.lemon.equivalence.registry.ModItems;
+import com.lemon.equivalence.registry.ModRecipes;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.client.itemgroup.FabricItemGroupBuilder;
 import net.minecraft.item.ItemGroup;
@@ -21,6 +22,7 @@ public class Equivalence implements ModInitializer {
     public void onInitialize() {
         ModItems.registerItems();
         ModBlocks.registerBlocks();
+        ModRecipes.registerRecipes();
 
         LootTableAdditions.modifyLootTables();
     }

--- a/src/main/java/com/lemon/equivalence/custom_items/Philosophers_Stone_Item.java
+++ b/src/main/java/com/lemon/equivalence/custom_items/Philosophers_Stone_Item.java
@@ -1,13 +1,15 @@
 package com.lemon.equivalence.custom_items;
 
 import com.lemon.equivalence.Equivalence;
+import com.lemon.equivalence.recipes.HasCustomRecipeRemainder;
 import com.lemon.equivalence.registry.ModItems;
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.util.Rarity;
 
 //Custom Item
-public class Philosophers_Stone_Item extends Item {
+public class Philosophers_Stone_Item extends Item implements HasCustomRecipeRemainder {
 
     public Philosophers_Stone_Item(Settings settings) {
         super(new FabricItemSettings()
@@ -21,6 +23,11 @@ public class Philosophers_Stone_Item extends Item {
     @Override
     public boolean hasRecipeRemainder() {
         return true;
+    }
+
+    @Override
+    public ItemStack getCustomRecipeRemainder(ItemStack initialStack) {
+        return initialStack.copy();
     }
 }
 

--- a/src/main/java/com/lemon/equivalence/custom_items/Philosophers_Stone_Item.java
+++ b/src/main/java/com/lemon/equivalence/custom_items/Philosophers_Stone_Item.java
@@ -16,7 +16,6 @@ public class Philosophers_Stone_Item extends Item implements HasCustomRecipeRema
                 .group(Equivalence.ITEM_GROUP) //CreativeTab
                 .maxCount(1) //Max Amount of Items in Stack
                 .rarity(Rarity.RARE) //Associated Color in Text for Rarity
-                .recipeRemainder(ModItems.DISCHARGED_STONE) //Remaining Item after Crafting Operation - Can't Return Self Oddly
         );
     }
 

--- a/src/main/java/com/lemon/equivalence/recipes/CustomRemainderRecipe.java
+++ b/src/main/java/com/lemon/equivalence/recipes/CustomRemainderRecipe.java
@@ -1,0 +1,41 @@
+package com.lemon.equivalence.recipes;
+
+import net.minecraft.inventory.CraftingInventory;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.RecipeSerializer;
+import net.minecraft.recipe.ShapelessRecipe;
+import net.minecraft.util.collection.DefaultedList;
+
+public class CustomRemainderRecipe extends ShapelessRecipe {
+
+    public CustomRemainderRecipe(ShapelessRecipe original) {
+        super(
+                original.getId(),
+                original.getGroup(),
+                original.getOutput(),
+                original.getIngredients()
+        );
+    }
+
+    @Override
+    public RecipeSerializer<?> getSerializer() {
+        return CustomRemainderRecipeSerializer.INSTANCE;
+    }
+
+    public DefaultedList<ItemStack> getRemainder(CraftingInventory inventory) {
+        DefaultedList<ItemStack> defaultedList = DefaultedList.ofSize(inventory.size(), ItemStack.EMPTY);
+
+        for(int i = 0; i < defaultedList.size(); ++i) {
+            ItemStack stack = inventory.getStack(i);
+            Item item = stack.getItem();
+            if (item instanceof HasCustomRecipeRemainder) {
+                defaultedList.set(i, ((HasCustomRecipeRemainder) item).getCustomRecipeRemainder(stack));
+            } else if (item.hasRecipeRemainder()) {
+                defaultedList.set(i, new ItemStack(item.getRecipeRemainder()));
+            }
+        }
+
+        return defaultedList;
+    }
+}

--- a/src/main/java/com/lemon/equivalence/recipes/CustomRemainderRecipeSerializer.java
+++ b/src/main/java/com/lemon/equivalence/recipes/CustomRemainderRecipeSerializer.java
@@ -1,0 +1,20 @@
+package com.lemon.equivalence.recipes;
+
+import com.google.gson.JsonObject;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.recipe.ShapelessRecipe;
+import net.minecraft.util.Identifier;
+
+public class CustomRemainderRecipeSerializer extends ShapelessRecipe.Serializer {
+    public static final CustomRemainderRecipeSerializer INSTANCE = new CustomRemainderRecipeSerializer();
+
+    @Override
+    public ShapelessRecipe read(Identifier identifier, JsonObject jsonObject) {
+        return new CustomRemainderRecipe(super.read(identifier, jsonObject));
+    }
+
+    @Override
+    public ShapelessRecipe read(Identifier identifier, PacketByteBuf packetByteBuf) {
+        return new CustomRemainderRecipe(super.read(identifier, packetByteBuf));
+    }
+}

--- a/src/main/java/com/lemon/equivalence/recipes/HasCustomRecipeRemainder.java
+++ b/src/main/java/com/lemon/equivalence/recipes/HasCustomRecipeRemainder.java
@@ -1,0 +1,7 @@
+package com.lemon.equivalence.recipes;
+
+import net.minecraft.item.ItemStack;
+
+public interface HasCustomRecipeRemainder {
+    ItemStack getCustomRecipeRemainder(ItemStack initialStack);
+}

--- a/src/main/java/com/lemon/equivalence/registry/ModBlocks.java
+++ b/src/main/java/com/lemon/equivalence/registry/ModBlocks.java
@@ -10,10 +10,10 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
 public class ModBlocks {
-    public static final Block BALANCE_BLOCK = new Block(FabricBlockSettings.of(Material.STONE).breakByTool(FabricToolTags.PICKAXES, 1).requiresTool().strength(3.0f, 20.0f).sounds(BlockSoundGroup.STONE));
-    public static final Block NITRO_COAL_BLOCK = new Block(FabricBlockSettings.of(Material.STONE).breakByTool(FabricToolTags.PICKAXES, 1).requiresTool().strength(3.0f, 20.0f).sounds(BlockSoundGroup.STONE));
-    public static final Block INFERNO_COAL_BLOCK = new Block(FabricBlockSettings.of(Material.STONE).breakByTool(FabricToolTags.PICKAXES, 1).requiresTool().strength(3.0f, 20.0f).sounds(BlockSoundGroup.STONE));
-    public static final Block BLAZING_COAL_BLOCK = new Block(FabricBlockSettings.of(Material.STONE).breakByTool(FabricToolTags.PICKAXES, 1).requiresTool().strength(3.0f, 20.0f).sounds(BlockSoundGroup.STONE));
+    public static final Block BALANCE_BLOCK = new Block(FabricBlockSettings.of(Material.STONE).requiresTool().strength(3.0f, 20.0f).sounds(BlockSoundGroup.STONE));
+    public static final Block NITRO_COAL_BLOCK = new Block(FabricBlockSettings.of(Material.STONE).requiresTool().strength(3.0f, 20.0f).sounds(BlockSoundGroup.STONE));
+    public static final Block INFERNO_COAL_BLOCK = new Block(FabricBlockSettings.of(Material.STONE).requiresTool().strength(3.0f, 20.0f).sounds(BlockSoundGroup.STONE));
+    public static final Block BLAZING_COAL_BLOCK = new Block(FabricBlockSettings.of(Material.STONE).requiresTool().strength(3.0f, 20.0f).sounds(BlockSoundGroup.STONE));
 
 public static void registerBlocks(){
     Registry.register(Registry.BLOCK, new Identifier(Equivalence.MOD_ID, "balance_block"), BALANCE_BLOCK);

--- a/src/main/java/com/lemon/equivalence/registry/ModRecipes.java
+++ b/src/main/java/com/lemon/equivalence/registry/ModRecipes.java
@@ -1,0 +1,16 @@
+package com.lemon.equivalence.registry;
+
+import com.lemon.equivalence.Equivalence;
+import com.lemon.equivalence.recipes.CustomRemainderRecipeSerializer;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+public class ModRecipes {
+    public static void registerRecipes() {
+        Registry.register(
+                Registry.RECIPE_SERIALIZER,
+                new Identifier(Equivalence.MOD_ID, "shapeless_custom_remainder"),
+                CustomRemainderRecipeSerializer.INSTANCE
+        );
+    }
+}

--- a/src/main/resources/data/equivalence/recipes/convert_acacia_log_to_dark_oak_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_acacia_log_to_dark_oak_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:shapeless_custom_remainder",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_acacia_planks_to_acacia_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_acacia_planks_to_acacia_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_acacia_planks_to_dark_oak_planks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_acacia_planks_to_dark_oak_planks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_acacia_sapling_to_dark_oak_sapling.json
+++ b/src/main/resources/data/equivalence/recipes/convert_acacia_sapling_to_dark_oak_sapling.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_acacia_slab_to_dark_oak_slab.json
+++ b/src/main/resources/data/equivalence/recipes/convert_acacia_slab_to_dark_oak_slab.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_acacia_stairs_to_dark_oak_stairs.json
+++ b/src/main/resources/data/equivalence/recipes/convert_acacia_stairs_to_dark_oak_stairs.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_ancient_debris_to_emerald_blocks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_ancient_debris_to_emerald_blocks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_birch_log_to_jungle_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_birch_log_to_jungle_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_birch_planks_to_birch_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_birch_planks_to_birch_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_birch_planks_to_jungle_planks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_birch_planks_to_jungle_planks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_birch_sapling_to_jungle_sapling.json
+++ b/src/main/resources/data/equivalence/recipes/convert_birch_sapling_to_jungle_sapling.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_birch_slab_to_jungle_slab.json
+++ b/src/main/resources/data/equivalence/recipes/convert_birch_slab_to_jungle_slab.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_birch_stairs_to_jungle_stairs.json
+++ b/src/main/resources/data/equivalence/recipes/convert_birch_stairs_to_jungle_stairs.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_black_dye_to_white_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_black_dye_to_white_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_blaze_powder_to_blaze_rod.json
+++ b/src/main/resources/data/equivalence/recipes/convert_blaze_powder_to_blaze_rod.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_blazing_coal_block_to_inferno_coal_blocks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_blazing_coal_block_to_inferno_coal_blocks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_blazing_coal_to_inferno_coal.json
+++ b/src/main/resources/data/equivalence/recipes/convert_blazing_coal_to_inferno_coal.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_blue_dye_to_brown_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_blue_dye_to_brown_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_bricks_block_to_bricks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_bricks_block_to_bricks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_brown_dye_to_green_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_brown_dye_to_green_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_chiseled_red_sandstone_to_cut_red_sandstone.json
+++ b/src/main/resources/data/equivalence/recipes/convert_chiseled_red_sandstone_to_cut_red_sandstone.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_chiseled_sandstone_to_cut_sandstone.json
+++ b/src/main/resources/data/equivalence/recipes/convert_chiseled_sandstone_to_cut_sandstone.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_chiseled_stone_bricks_to_stone_bricks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_chiseled_stone_bricks_to_stone_bricks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_clay_ball_to_gravel.json
+++ b/src/main/resources/data/equivalence/recipes/convert_clay_ball_to_gravel.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_clay_block_to_clay_balls.json
+++ b/src/main/resources/data/equivalence/recipes/convert_clay_block_to_clay_balls.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_clay_block_to_iron_ingot.json
+++ b/src/main/resources/data/equivalence/recipes/convert_clay_block_to_iron_ingot.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_coal_blocks_to_nitro_coal_block.json
+++ b/src/main/resources/data/equivalence/recipes/convert_coal_blocks_to_nitro_coal_block.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_coal_to_nitro_coal.json
+++ b/src/main/resources/data/equivalence/recipes/convert_coal_to_nitro_coal.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:shapeless_custom_remainder",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_cobblestone_to_flint.json
+++ b/src/main/resources/data/equivalence/recipes/convert_cobblestone_to_flint.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_cobblestone_to_grass.json
+++ b/src/main/resources/data/equivalence/recipes/convert_cobblestone_to_grass.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_copper_blocks_to_iron_blocks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_copper_blocks_to_iron_blocks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_copper_ingots_to_iron_ingots.json
+++ b/src/main/resources/data/equivalence/recipes/convert_copper_ingots_to_iron_ingots.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_cracked_stone_bricks_to_chiseled_stone_bricks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_cracked_stone_bricks_to_chiseled_stone_bricks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_crimson_planks_to_crimson_stem.json
+++ b/src/main/resources/data/equivalence/recipes/convert_crimson_planks_to_crimson_stem.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_crimson_planks_to_warped_planks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_crimson_planks_to_warped_planks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_crimson_slab_to_warped_slab.json
+++ b/src/main/resources/data/equivalence/recipes/convert_crimson_slab_to_warped_slab.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_crimson_stairs_to_warped_stairs.json
+++ b/src/main/resources/data/equivalence/recipes/convert_crimson_stairs_to_warped_stairs.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_crimson_stem_to_warped_stem.json
+++ b/src/main/resources/data/equivalence/recipes/convert_crimson_stem_to_warped_stem.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_cut_red_sandstone_to_flint.json
+++ b/src/main/resources/data/equivalence/recipes/convert_cut_red_sandstone_to_flint.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_cut_sandstone_to_flint.json
+++ b/src/main/resources/data/equivalence/recipes/convert_cut_sandstone_to_flint.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_cyan_dye_to_purple_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_cyan_dye_to_purple_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_dandelion_to_poppy.json
+++ b/src/main/resources/data/equivalence/recipes/convert_dandelion_to_poppy.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_dark_oak_log_to_oak_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_dark_oak_log_to_oak_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_dark_oak_planks_to_dark_oak_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_dark_oak_planks_to_dark_oak_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_dark_oak_planks_to_oak_planks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_dark_oak_planks_to_oak_planks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_dark_oak_sapling_to_oak_sapling.json
+++ b/src/main/resources/data/equivalence/recipes/convert_dark_oak_sapling_to_oak_sapling.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_dark_oak_slab_to_oak_slab.json
+++ b/src/main/resources/data/equivalence/recipes/convert_dark_oak_slab_to_oak_slab.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_dark_oak_stairs_to_oak_stairs.json
+++ b/src/main/resources/data/equivalence/recipes/convert_dark_oak_stairs_to_oak_stairs.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_diamond_block_to_gold_blocks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_diamond_block_to_gold_blocks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_diamond_blocks_to_emerald_block.json
+++ b/src/main/resources/data/equivalence/recipes/convert_diamond_blocks_to_emerald_block.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_diamond_to_gold_ingots.json
+++ b/src/main/resources/data/equivalence/recipes/convert_diamond_to_gold_ingots.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_diamonds_to_emeralds.json
+++ b/src/main/resources/data/equivalence/recipes/convert_diamonds_to_emeralds.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_dirt_to_cobblesone.json
+++ b/src/main/resources/data/equivalence/recipes/convert_dirt_to_cobblesone.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_dirt_to_gravel.json
+++ b/src/main/resources/data/equivalence/recipes/convert_dirt_to_gravel.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_emerald_block_to_diamond_blocks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_emerald_block_to_diamond_blocks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_emerald_blocks_to_ancient_debris.json
+++ b/src/main/resources/data/equivalence/recipes/convert_emerald_blocks_to_ancient_debris.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_emerald_to_diamonds.json
+++ b/src/main/resources/data/equivalence/recipes/convert_emerald_to_diamonds.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_ender_pearl_to_iron_ingots.json
+++ b/src/main/resources/data/equivalence/recipes/convert_ender_pearl_to_iron_ingots.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_flint_to_clay_ball.json
+++ b/src/main/resources/data/equivalence/recipes/convert_flint_to_clay_ball.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_flint_to_cobblestone.json
+++ b/src/main/resources/data/equivalence/recipes/convert_flint_to_cobblestone.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_flint_to_gravel.json
+++ b/src/main/resources/data/equivalence/recipes/convert_flint_to_gravel.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_glowstone_block_to_glowstone_dust.json
+++ b/src/main/resources/data/equivalence/recipes/convert_glowstone_block_to_glowstone_dust.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_gold_block_to_iron_blocks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_gold_block_to_iron_blocks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_gold_blocks_to_diamond_block.json
+++ b/src/main/resources/data/equivalence/recipes/convert_gold_blocks_to_diamond_block.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_gold_ingot_to_iron_ingots.json
+++ b/src/main/resources/data/equivalence/recipes/convert_gold_ingot_to_iron_ingots.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_gold_ingots_to_diamond.json
+++ b/src/main/resources/data/equivalence/recipes/convert_gold_ingots_to_diamond.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_grass_to_sand.json
+++ b/src/main/resources/data/equivalence/recipes/convert_grass_to_sand.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_gravel_to_clay_ball.json
+++ b/src/main/resources/data/equivalence/recipes/convert_gravel_to_clay_ball.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_gravel_to_dirt.json
+++ b/src/main/resources/data/equivalence/recipes/convert_gravel_to_dirt.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_gravel_to_sandstone.json
+++ b/src/main/resources/data/equivalence/recipes/convert_gravel_to_sandstone.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_gray_dye_to_light_gray_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_gray_dye_to_light_gray_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_green_dye_to_red_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_green_dye_to_red_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_inferno_coal_block_to_nitro_coal_blocks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_inferno_coal_block_to_nitro_coal_blocks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_inferno_coal_block_to_nitro_coal_blocks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_inferno_coal_block_to_nitro_coal_blocks.json
@@ -5,7 +5,7 @@
       "item": "equivalence:philosophers_stone"
     },
     {
-      "item": "equivalence:inferno_coal_blocks"
+      "item": "equivalence:inferno_coal_block"
     }
   ],
   "result": {

--- a/src/main/resources/data/equivalence/recipes/convert_inferno_coal_blocks_to_blazing_coal_block.json
+++ b/src/main/resources/data/equivalence/recipes/convert_inferno_coal_blocks_to_blazing_coal_block.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_inferno_coal_to_blazing_coal.json
+++ b/src/main/resources/data/equivalence/recipes/convert_inferno_coal_to_blazing_coal.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_inferno_coal_to_nitro_coal.json
+++ b/src/main/resources/data/equivalence/recipes/convert_inferno_coal_to_nitro_coal.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_iron_blocks_to_copper_blocks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_iron_blocks_to_copper_blocks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_iron_blocks_to_gold_block.json
+++ b/src/main/resources/data/equivalence/recipes/convert_iron_blocks_to_gold_block.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_iron_ingot_to_ender_pearl.json
+++ b/src/main/resources/data/equivalence/recipes/convert_iron_ingot_to_ender_pearl.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_iron_ingots_to_clay_blocks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_iron_ingots_to_clay_blocks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_iron_ingots_to_copper_ingots.json
+++ b/src/main/resources/data/equivalence/recipes/convert_iron_ingots_to_copper_ingots.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_iron_ingots_to_gold_ingot.json
+++ b/src/main/resources/data/equivalence/recipes/convert_iron_ingots_to_gold_ingot.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_jungle_log_to_acacia_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_jungle_log_to_acacia_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_jungle_planks_to_acacia_planks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_jungle_planks_to_acacia_planks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_jungle_planks_to_jungle_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_jungle_planks_to_jungle_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_jungle_sapling_to_acacia_sapling.json
+++ b/src/main/resources/data/equivalence/recipes/convert_jungle_sapling_to_acacia_sapling.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_jungle_slab_to_acacia_slab.json
+++ b/src/main/resources/data/equivalence/recipes/convert_jungle_slab_to_acacia_slab.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_jungle_stairs_to_acacia_stairs.json
+++ b/src/main/resources/data/equivalence/recipes/convert_jungle_stairs_to_acacia_stairs.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_light_blue_dye_to_yellow_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_light_blue_dye_to_yellow_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_light_gray_dye_to_cyan_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_light_gray_dye_to_cyan_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_lime_dye_to_pink_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_lime_dye_to_pink_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_logs_to_obsidian.json
+++ b/src/main/resources/data/equivalence/recipes/convert_logs_to_obsidian.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_magenta_dye_to_light_blue_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_magenta_dye_to_light_blue_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_melon_to_pumpkin.json
+++ b/src/main/resources/data/equivalence/recipes/convert_melon_to_pumpkin.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_mossy_stone_bricks_to_cracked_stone_bricks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_mossy_stone_bricks_to_cracked_stone_bricks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_nitro_coal_blocks_to_inferno_coal_block.json
+++ b/src/main/resources/data/equivalence/recipes/convert_nitro_coal_blocks_to_inferno_coal_block.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_nitro_coal_to_coal.json
+++ b/src/main/resources/data/equivalence/recipes/convert_nitro_coal_to_coal.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_nitro_coal_to_inferno_coal.json
+++ b/src/main/resources/data/equivalence/recipes/convert_nitro_coal_to_inferno_coal.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_oak_log_to_spruce_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_oak_log_to_spruce_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_oak_planks_to_oak_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_oak_planks_to_oak_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_oak_planks_to_spruce_planks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_oak_planks_to_spruce_planks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_oak_sapling_to_spruce_sapling.json
+++ b/src/main/resources/data/equivalence/recipes/convert_oak_sapling_to_spruce_sapling.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_oak_slab_to_spruce_slab.json
+++ b/src/main/resources/data/equivalence/recipes/convert_oak_slab_to_spruce_slab.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_oak_stairs_to_spruce_stairs.json
+++ b/src/main/resources/data/equivalence/recipes/convert_oak_stairs_to_spruce_stairs.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_obsidian_to_iron_ingot.json
+++ b/src/main/resources/data/equivalence/recipes/convert_obsidian_to_iron_ingot.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_obsidian_to_oak_logs.json
+++ b/src/main/resources/data/equivalence/recipes/convert_obsidian_to_oak_logs.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_orange_dye_to_magenta_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_orange_dye_to_magenta_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_pink_dye_to_gray_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_pink_dye_to_gray_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_poppy_to_dandelion.json
+++ b/src/main/resources/data/equivalence/recipes/convert_poppy_to_dandelion.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_pumpkin_to_melon.json
+++ b/src/main/resources/data/equivalence/recipes/convert_pumpkin_to_melon.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_purple_dye_to_blue_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_purple_dye_to_blue_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_red_dye_to_black_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_red_dye_to_black_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_red_sand_to_dirt.json
+++ b/src/main/resources/data/equivalence/recipes/convert_red_sand_to_dirt.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_red_sandstone_to_chiseled_red_sandstone.json
+++ b/src/main/resources/data/equivalence/recipes/convert_red_sandstone_to_chiseled_red_sandstone.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_red_sandstone_to_clay_ball.json
+++ b/src/main/resources/data/equivalence/recipes/convert_red_sandstone_to_clay_ball.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_red_sandstone_to_sand.json
+++ b/src/main/resources/data/equivalence/recipes/convert_red_sandstone_to_sand.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_sand_to_red_sand.json
+++ b/src/main/resources/data/equivalence/recipes/convert_sand_to_red_sand.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_sandstone_to_chiseled_sandstone.json
+++ b/src/main/resources/data/equivalence/recipes/convert_sandstone_to_chiseled_sandstone.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_sandstone_to_clay_ball.json
+++ b/src/main/resources/data/equivalence/recipes/convert_sandstone_to_clay_ball.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_sandstone_to_sand.json
+++ b/src/main/resources/data/equivalence/recipes/convert_sandstone_to_sand.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_spruce_log_to_birch_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_spruce_log_to_birch_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_spruce_planks_to_birch_planks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_spruce_planks_to_birch_planks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_spruce_planks_to_spruce_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_spruce_planks_to_spruce_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_spruce_sapling_to_birch_sapling.json
+++ b/src/main/resources/data/equivalence/recipes/convert_spruce_sapling_to_birch_sapling.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_spruce_slab_to_birch_slab.json
+++ b/src/main/resources/data/equivalence/recipes/convert_spruce_slab_to_birch_slab.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_spruce_stairs_to_birch_stairs.json
+++ b/src/main/resources/data/equivalence/recipes/convert_spruce_stairs_to_birch_stairs.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_sticks_to_oak_planks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_sticks_to_oak_planks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_stone_bricks_to_mossy_stone_bricks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_stone_bricks_to_mossy_stone_bricks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_stripped_acacia_log_to_stripped_dark_oak_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_stripped_acacia_log_to_stripped_dark_oak_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_stripped_birch_log_to_stripped_jungle_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_stripped_birch_log_to_stripped_jungle_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_stripped_crimson_stem_to_stripped_warped_stem.json
+++ b/src/main/resources/data/equivalence/recipes/convert_stripped_crimson_stem_to_stripped_warped_stem.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_stripped_dark_oak_log_to_stripped_oak_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_stripped_dark_oak_log_to_stripped_oak_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_stripped_jungle_log_to_stripped_acacia_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_stripped_jungle_log_to_stripped_acacia_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_stripped_oak_log_to_stripped_spruce_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_stripped_oak_log_to_stripped_spruce_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_stripped_spruce_log_to_stripped_birch_log.json
+++ b/src/main/resources/data/equivalence/recipes/convert_stripped_spruce_log_to_stripped_birch_log.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_stripped_warped_stem_to_stripped_crimson_stem.json
+++ b/src/main/resources/data/equivalence/recipes/convert_stripped_warped_stem_to_stripped_crimson_stem.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_warped_planks_to_crimson_planks.json
+++ b/src/main/resources/data/equivalence/recipes/convert_warped_planks_to_crimson_planks.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_warped_planks_to_warped_stem.json
+++ b/src/main/resources/data/equivalence/recipes/convert_warped_planks_to_warped_stem.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_warped_slab_to_crimson_slab.json
+++ b/src/main/resources/data/equivalence/recipes/convert_warped_slab_to_crimson_slab.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_warped_stairs_to_crimson_stairs.json
+++ b/src/main/resources/data/equivalence/recipes/convert_warped_stairs_to_crimson_stairs.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_warped_stem_to_crimson_stem.json
+++ b/src/main/resources/data/equivalence/recipes/convert_warped_stem_to_crimson_stem.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_white_dye_to_orange_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_white_dye_to_orange_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/equivalence/recipes/convert_yellow_dye_to_lime_dye.json
+++ b/src/main/resources/data/equivalence/recipes/convert_yellow_dye_to_lime_dye.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shapeless",
+  "type": "equivalence:custom_remainder_shapeless",
   "ingredients": [
     {
       "item": "equivalence:philosophers_stone"

--- a/src/main/resources/data/minecraft/blocks/mineable/pickaxe.json
+++ b/src/main/resources/data/minecraft/blocks/mineable/pickaxe.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "equivalence:balance_block",
+    "equivalence:nitro_coal_block",
+    "equivalence:inferno_coal_block",
+    "equivalence:blazing_coal_block"
+  ]
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "equivalence",
-  "version": "1.2.1",
+  "version": "1.2.2",
 
   "name": "Equivalence",
   "description": "A Mod About Equivalence!\nTo obtain, something of equal value must be lost. That is Alchemy's first law of Equivalent Exchange.",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -26,10 +26,10 @@
   ],
 
   "depends": {
-    "fabricloader": ">=0.11.3",
+    "fabricloader": ">=0.12.11",
     "fabric": "*",
-    "minecraft": "1.17.x",
-	"java": ">=16"
+    "minecraft": "1.18.x",
+	"java": ">=17"
   },
   "suggests": {
     "another-mod": "*"


### PR DESCRIPTION
**NOTE:** This is also includes the update to Minecraft 1.18.1. I only tested the changes on this version, so I didn't want to submit them separately. If you want this to be merged in separately, let me know and I can remove the 1.18.1-related commits from this branch.

Adds `CustomRemainderRecipe`, which is equivalent to `ShapelessRecipe` but checks if each item implements `HasCustomRecipeRemainder`. If an item in the recipe implements `HasCustomRecipeRemainder`, the `getCustomRecipeRemainder` function is called on the item to determine what the remainder will be.

This is primarily intended to allow returning a Philosophers Stone from conversion recipes instead of a Discharged Stone, but also provides future flexibility to define custom recipe remainders on other items.

Also changes the type of all recipes with the Philosophers Stone as an ingredient to `"equivalence:shapeless_custom_remainder"` so the Philosophers Stone itself can be returned.

Because this custom recipe type overrides the standard `recipeRemainder` behavior for items that implement `HasCustomRecipeRemainder`, I also removed the call to `recipeRemainder` that previously set the Philosophers Stone to return a Discharged Stone as its remainder.